### PR TITLE
Efficiency Fix: Added the get_queryset method and model declaration implementation

### DIFF
--- a/django_serverside_datatable/views.py
+++ b/django_serverside_datatable/views.py
@@ -1,15 +1,40 @@
 from django.views import View
 from django.http import JsonResponse
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import QuerySet
 from django_serverside_datatable import datatable
 
 
 class ServerSideDatatableView(View):
     queryset = None
     columns = None
+    model = None
 
     def get(self, request, *args, **kwargs):
-        result = datatable.DataTablesServer(request, self.columns, self.queryset).output_result()
+        result = datatable.DataTablesServer(
+            request, self.columns, self.get_queryset()).output_result()
         return JsonResponse(result, safe=False)
 
+    def get_queryset(self):
+        """
+        Return the list of items for this view.
 
+        The return value must be an iterable and may be an instance of
+        `QuerySet` in which case `QuerySet` specific behavior will be enabled.
+        """
+        if self.queryset is not None:
+            queryset = self.queryset
+            if isinstance(queryset, QuerySet):
+                queryset = queryset.all()
+        elif self.model is not None:
+            queryset = self.model._default_manager.all()
+        else:
+            raise ImproperlyConfigured(
+                "%(cls)s is missing a QuerySet. Define "
+                "%(cls)s.model, %(cls)s.queryset, or override "
+                "%(cls)s.get_queryset()." % {
+                    'cls': self.__class__.__name__
+                }
+            )
 
+        return queryset


### PR DESCRIPTION
I think it would be more efficient and more dynamic if it were possible to include a `model` attribute, and a `get_queryset()` method in the main View, and then use  `self.get_queryset()` instead of `self.queryset` in the `get` method.
See the suggested code changes
